### PR TITLE
v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Media Downloader** is a custom Home Assistant integration to manage media files directly from Home Assistant through simple services.  
 
-Version **v1.0.1** adds new services for deleting individual files and clearing directories.
+Version **v1.0.2** adds support for configuring default delete paths via the UI.
 
 ---
 
@@ -12,6 +12,7 @@ Version **v1.0.1** adds new services for deleting individual files and clearing 
 - Overwrite policy (default or per call).
 - Event triggers for downloads and deletions.
 - Delete a single file or all files in a directory via services.
+- Default delete paths can be set in the UI (OptionsFlow).
 - Works with Home Assistant automations and scripts.
 
 ---
@@ -52,6 +53,8 @@ Version **v1.0.1** adds new services for deleting individual files and clearing 
 When adding the integration:
 - **Base download directory**: Absolute path where files will be saved.
 - **Overwrite**: Whether existing files should be replaced by default.
+- **Default file delete path**: Optional, used if no path is passed to the `delete_file` service.
+- **Default directory delete path**: Optional, used if no path is passed to the `delete_files_in_directory` service.
 
 You can change these settings later using the integration options.
 
@@ -85,12 +88,13 @@ Downloads a file from the specified URL.
 ---
 
 ### 2. `media_downloader.delete_file`
-Deletes the specified file if it exists.
+Deletes the specified file if it exists.  
+If `path` is not provided, the default path configured in the UI will be used.
 
 #### Service Data
-| Field  | Required | Description                    |
-|---------|----------|--------------------------------|
-| `path`  | yes      | Absolute path to the file.      |
+| Field  | Required | Description                                |
+|---------|----------|--------------------------------------------|
+| `path`  | no       | Absolute path to the file (overrides UI). |
 
 #### Example:
 ```
@@ -102,12 +106,13 @@ Deletes the specified file if it exists.
 ---
 
 ### 3. `media_downloader.delete_files_in_directory`
-Deletes all files inside the specified directory.
+Deletes all files inside the specified directory.  
+If `path` is not provided, the default directory configured in the UI will be used.
 
 #### Service Data
-| Field  | Required | Description                    |
-|---------|----------|--------------------------------|
-| `path`  | yes      | Absolute path to the directory. |
+| Field  | Required | Description                                        |
+|---------|----------|----------------------------------------------------|
+| `path`  | no       | Absolute path to the directory (overrides UI).     |
 
 #### Example:
 ```
@@ -166,6 +171,20 @@ Each event contains:
             title: "Media Downloader"
             message: "Error: {{ wait.trigger.event.data.error }}"
 ```
+
+---
+
+## Changelog
+
+### v1.0.2 - 2025-08-23
+#### Added
+- New service `media_downloader.delete_file`: deletes a specific file by providing `path` or using default UI-configured path.
+- New service `media_downloader.delete_files_in_directory`: deletes all files inside the specified directory by providing `path` or using default UI-configured path.
+- New events:
+  - `media_downloader_delete_completed`
+  - `media_downloader_delete_directory_completed`
+- Added installation instructions for both manual setup and HACS.
+- Added UI options to configure default paths for file and directory deletion.
 
 #### Changed
 - Updated documentation and examples.

--- a/custom_components/media_downloader/config_flow.py
+++ b/custom_components/media_downloader/config_flow.py
@@ -11,6 +11,8 @@ from .const import (
     DOMAIN,
     CONF_DOWNLOAD_DIR,
     CONF_OVERWRITE,
+    CONF_DELETE_FILE_PATH,
+    CONF_DELETE_DIR_PATH,
     DEFAULT_OVERWRITE,
 )
 
@@ -34,9 +36,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
 
     @staticmethod
     @callback
-    def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
-    ) -> config_entries.OptionsFlow:
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
         return OptionsFlow(config_entry)
 
 
@@ -54,11 +54,15 @@ class OptionsFlow(config_entries.OptionsFlow):
         overwrite = self.config_entry.options.get(
             CONF_OVERWRITE, self.config_entry.data.get(CONF_OVERWRITE, DEFAULT_OVERWRITE)
         )
+        delete_file_path = self.config_entry.options.get(CONF_DELETE_FILE_PATH, "")
+        delete_dir_path = self.config_entry.options.get(CONF_DELETE_DIR_PATH, "")
 
         schema = vol.Schema(
             {
                 vol.Required(CONF_DOWNLOAD_DIR, default=download_dir): str,
                 vol.Optional(CONF_OVERWRITE, default=overwrite): bool,
+                vol.Optional(CONF_DELETE_FILE_PATH, default=delete_file_path): str,
+                vol.Optional(CONF_DELETE_DIR_PATH, default=delete_dir_path): str,
             }
         )
 

--- a/custom_components/media_downloader/const.py
+++ b/custom_components/media_downloader/const.py
@@ -2,6 +2,8 @@ DOMAIN = "media_downloader"
 
 CONF_DOWNLOAD_DIR = "download_dir"
 CONF_OVERWRITE = "overwrite"
+CONF_DELETE_FILE_PATH = "delete_file_path"
+CONF_DELETE_DIR_PATH = "delete_directory_path"
 
 DEFAULT_OVERWRITE = False
 

--- a/custom_components/media_downloader/manifest.json
+++ b/custom_components/media_downloader/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "quality_scale": "legacy",
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/media_downloader/services.yaml
+++ b/custom_components/media_downloader/services.yaml
@@ -3,26 +3,36 @@ download_file:
   description: Download a file to the configured directory with optional subdir and filename.
   fields:
     url:
+      name: URL
+      description: The URL of the file to download.
       required: true
       example: "https://example.com/file.mp4"
       selector:
         text:
     subdir:
+      name: Subdirectory
+      description: Relative download path.
       required: false
       example: "ring"
       selector:
         text:
     filename:
+      name: Filename
+      description: Custom name for the downloaded file.
       required: false
       example: "video.mp4"
       selector:
         text:
     overwrite:
+      name: Overwrite
+      description: Overwrite file if it exists.
       required: false
       default: false
       selector:
         boolean:
     timeout:
+      name: Timeout
+      description: Download timeout in seconds.
       required: false
       default: 300
       selector:
@@ -30,3 +40,27 @@ download_file:
           min: 1
           max: 3600
           mode: box
+
+delete_file:
+  name: Delete file
+  description: Delete a specific file from the configured base directory.
+  fields:
+    path:
+      name: File path
+      description: Absolute path to the file to delete. If not provided, the default UI-configured path will be used.
+      required: false
+      example: "/media/ring/video.mp4"
+      selector:
+        text:
+
+delete_files_in_directory:
+  name: Delete files in directory
+  description: Delete all files inside the specified directory.
+  fields:
+    path:
+      name: Directory path
+      description: Absolute path to the directory to clear. If not provided, the default UI-configured directory will be used.
+      required: false
+      example: "/media/ring"
+      selector:
+        text:


### PR DESCRIPTION
# Changelog

## v1.0.3 - 2025-09-03
### Added
- Enhanced `services.yaml` definitions:
  - Added `name` and `description` metadata for all service fields (`download_file`, `delete_file`, `delete_files_in_directory`).
  - Improved UI integration so service parameters are displayed with friendly labels and help text instead of raw YAML blocks.
- Clearer examples for `delete_file` and `delete_files_in_directory` in the Home Assistant automation editor.

### Changed
- Documentation updated to reflect improved service UI support.

### Fixed
- Resolved issue where `delete_file` and `delete_files_in_directory` only appeared as YAML snippets in the UI; now they render as proper form fields.